### PR TITLE
Das "offizielle" von bund.dev entfernt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ List of various APIs/Open Data sources in relation to Germany.
 
 # List
 
-- [API-Portal des Bundes](https://github.com/forensicgato/germany-open-data#api-portal-des-bundes)
+- [API-Portal bund.dev](https://github.com/forensicgato/germany-open-data#api-portal-des-bundes)
   - [RKI Risikogebiete](https://github.com/forensicgato/germany-open-data#rki-risikogebiete)
   - [NINA](https://github.com/forensicgato/germany-open-data#nina)
   - [DWD](https://github.com/forensicgato/germany-open-data#dwd)
@@ -33,7 +33,7 @@ List of various APIs/Open Data sources in relation to Germany.
   - [FragDenStaat API](https://github.com/forensicgato/germany-open-data#fragdenstaat-api)
 
 
-## [API-Portal des Bundes](https://bund.dev/)
+## [API-Portal bund.dev](https://bund.dev/)
 
 ### [RKI Risikogebiete](https://risikogebiete.api.bund.dev/)
 


### PR DESCRIPTION
Bei z.B. solchen Kommentaren in den Repos https://github.com/bundesAPI/autobahn-api#autobahn-app-api 

![Bildschirmfoto 2021-08-08 um 22 02 51](https://user-images.githubusercontent.com/35926/128644313-fca915d6-4f06-433d-b53d-8eb20b332bb5.png)

wirkt das nicht so, als wenn bund.dev irgendeinen offiziellen Charakter hat.

Es wirkt eher wie eine ehrenamtliche Organisation (hauptsächlich von LilithWittmann), die OpenAPI-Specs (analog zu dem @germany-open-data repo) sammelt und zur Verfügung stellt.